### PR TITLE
Saver redefinition of verbatim environment

### DIFF
--- a/latex/preamble.tex
+++ b/latex/preamble.tex
@@ -35,9 +35,11 @@
 \makeatletter
 \@ifundefined{Shaded}{
 }{\renewenvironment{Shaded}{\begin{kframe}}{\end{kframe}}}
+\@ifpackageloaded{fanyverb}{%
+  % https://github.com/CTeX-org/ctex-kit/issues/331
+  \RecustomVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\},formatcom=\xeCJKVerbAddon}%
+}{}
 \makeatother
-% https://github.com/CTeX-org/ctex-kit/issues/331
-\RecustomVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\},formatcom=\xeCJKVerbAddon}
 
 \usepackage{makeidx}
 \makeindex


### PR DESCRIPTION
Calling `\RecustomVerbatimEnvironment` fails if `fancyvrb` has not been loaded because there are no code chunks to be formatted. See also https://stackoverflow.com/questions/50634245/why-some-r-codes-have-to-be-included-in-index-rmd-of-bookdown for the original question and https://tex.stackexchange.com/questions/16199/test-if-a-package-or-package-option-is-loaded for the used solution.